### PR TITLE
Fix the “test” extra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,8 +24,8 @@ content-type = "text/markdown"
 [options]
 zip_safe = false
 
-[options.extras_require]
-test = "pytest"
+[project.optional-dependencies]
+test = ["pytest"]
 
 [tool.cibuildwheel]
 test-requires = "pytest"


### PR DESCRIPTION
Replace `[options.extras_require]` with `[project.optional-dependencies]` as required for `pyproject.toml`.

Test with:

```
python3.11 -m venv _e
. _e/bin/activate
pip install -e .[test]
```

which works as expected after this PR (but not before it).