### PR TITLE
Feature: Numpy 2 Support. 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,14 +2,14 @@
 requires = [
     "setuptools>=42",
     "wheel",
-    "pybind11>=2.10.0",
+    "pybind11>=2.12.0",
 ]
 build-backend = "setuptools.build_meta"
 
 
 [project]
 name = "vhacdx"
-version = "0.0.6"
+version = "0.0.7"
 requires-python = ">=3.7"
 
 authors = [{name = "Thomas Wolf", email = "thomas@huggingface.co"}]


### PR DESCRIPTION
Updates pybind to support Numpy 1+2, more details [in this PR](https://github.com/skogler/mapbox_earcut_python/pull/15).  This fixes issue seen [in this build](https://github.com/mikedh/trimesh/actions/runs/9423509140/job/25962040568?pr=2238).
